### PR TITLE
Fix #23 Make username a single-line text field, press next on keyboard to directly enter password field

### DIFF
--- a/visionppi/app/src/main/res/layout/activity_login.xml
+++ b/visionppi/app/src/main/res/layout/activity_login.xml
@@ -61,6 +61,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="@string/input_username" android:id="@+id/et_username"
+                        android:singleLine="true"
                         android:layout_marginBottom="@dimen/text_input_spacing"/>
 
                 <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
Fix #23 

The username edittext is now single line and pressing the next button on the keyboard directly leads to the password edittext. 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/41234408/77936628-ca3d4b00-72d0-11ea-8e8f-048ecb7499a3.gif)
