### PR TITLE
Disabled search button when search query is empty

### DIFF
--- a/visionppi/app/src/main/java/org/mifos/visionppi/ui/home/MainActivity.kt
+++ b/visionppi/app/src/main/java/org/mifos/visionppi/ui/home/MainActivity.kt
@@ -2,6 +2,8 @@ package org.mifos.visionppi.ui.home
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import com.google.android.material.navigation.NavigationView
 import androidx.core.view.GravityCompat
 import androidx.appcompat.app.ActionBarDrawerToggle
@@ -40,6 +42,27 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
         client_search_list.layoutManager = LinearLayoutManager(this)
+        search_btn.alpha = 0.5F
+        search_query.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(p0: Editable?) {
+
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                if(p0.toString().trim().isEmpty()){
+                    search_btn?.isEnabled = false
+                    search_btn.alpha = 0.5F
+                }else{
+                    search_btn.isEnabled = true
+                    search_btn.alpha = 1.0F
+                }
+            }
+
+        })
 
 
         search_btn.setOnClickListener {

--- a/visionppi/app/src/main/res/layout/content_main.xml
+++ b/visionppi/app/src/main/res/layout/content_main.xml
@@ -62,13 +62,14 @@
 
 
         <Button
-                android:text="@string/search"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
                 android:id="@+id/search_btn"
                 style="@style/Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/ll_margin"
                 android:layout_marginBottom="@dimen/text_input_spacing"
-                android:layout_marginTop="@dimen/ll_margin"/>
+                android:enabled="false"
+                android:text="@string/search" />
 
         <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/client_search_list"


### PR DESCRIPTION
Fixes #42 
Search button was made translucent and disabled when search query is empty and it again becomes opaque and enabled when search query is not empty