### PR TITLE
Added check for internet connectivity in search button

### DIFF
--- a/visionppi/app/src/main/AndroidManifest.xml
+++ b/visionppi/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="org.mifos.visionppi">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA"/>

--- a/visionppi/app/src/main/java/org/mifos/visionppi/ui/home/MainActivity.kt
+++ b/visionppi/app/src/main/java/org/mifos/visionppi/ui/home/MainActivity.kt
@@ -1,6 +1,8 @@
 package org.mifos.visionppi.ui.home
 
+import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.os.Bundle
 import com.google.android.material.navigation.NavigationView
 import androidx.core.view.GravityCompat
@@ -44,12 +46,15 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
         search_btn.setOnClickListener {
 
-            search_query.onEditorAction(EditorInfo.IME_ACTION_DONE)
-            if(search_query.text.toString().length == 0)
-                searchError()
-
-            else
-                search(search_query.text.toString())
+            if (networkAvailable(this)) {
+                search_query.onEditorAction(EditorInfo.IME_ACTION_DONE)
+                if (search_query.text.toString().length == 0)
+                    searchError()
+                else
+                    search(search_query.text.toString())
+            } else {
+                showToastMessage("Internet connection not available. Please check network settings")
+            }
         }
 
         val toggle = ActionBarDrawerToggle(
@@ -59,6 +64,12 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         toggle.syncState()
 
         nav_view.setNavigationItemSelectedListener(this)
+    }
+
+    private fun networkAvailable (activity:AppCompatActivity): Boolean{
+        val connectivityManager = activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val networkInfo = connectivityManager.activeNetworkInfo
+        return  networkInfo != null && networkInfo.isConnected
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
Fix #54 

If internet connection is missing, a user is shown a toast message giving the appropriate error. 

![screencap](https://user-images.githubusercontent.com/41234408/78336984-e0d3f280-75ad-11ea-9848-e42879f33013.png)
