### PR TITLE
Added internet connectivity check in the login screen

### DIFF
--- a/visionppi/app/src/main/AndroidManifest.xml
+++ b/visionppi/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="org.mifos.visionppi">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA"/>

--- a/visionppi/app/src/main/java/org/mifos/visionppi/ui/login/LoginActivity.kt
+++ b/visionppi/app/src/main/java/org/mifos/visionppi/ui/login/LoginActivity.kt
@@ -1,6 +1,8 @@
 package org.mifos.visionppi.ui.login
 
+import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -32,7 +34,11 @@ class LoginActivity: AppCompatActivity(), LoginMVPView {
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_login)
         binding.loginBtn.setOnClickListener {
-            login()
+            if (networkAvailable(this)) {
+                login()
+            } else {
+                showToastMessage("Internet connection not available. Please check network settings")
+            }
         }
 
     }
@@ -79,6 +85,12 @@ class LoginActivity: AppCompatActivity(), LoginMVPView {
 
     override fun onLoginError() {
         showToastMessage(getString(R.string.login_fail))
+    }
+
+    private fun networkAvailable (activity:AppCompatActivity): Boolean{
+        val connectivityManager = activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val networkInfo = connectivityManager.activeNetworkInfo
+        return  networkInfo != null && networkInfo.isConnected
     }
 
 }


### PR DESCRIPTION
Fix #47 

Added check for an internet connection while logging in and display a toast if device is offline. 

![screencap](https://user-images.githubusercontent.com/41234408/78337702-057c9a00-75af-11ea-8d54-e4136b2db77a.png)
