### PR TITLE
Fix #44 Clicking on profile opens profile page

### DIFF
--- a/visionppi/app/src/main/java/org/mifos/visionppi/ui/home/MainActivity.kt
+++ b/visionppi/app/src/main/java/org/mifos/visionppi/ui/home/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.mifos.visionppi.ui.home
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import com.google.android.material.navigation.NavigationView
@@ -8,13 +9,16 @@ import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar_main.*
 import kotlinx.android.synthetic.main.content_main.*
+import kotlinx.android.synthetic.main.nav_header_main.*
 import org.mifos.visionppi.R
 import org.mifos.visionppi.adapters.ClientSearchAdapter
 import org.mifos.visionppi.databinding.ActivityMainBinding
@@ -52,9 +56,27 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                 search(search_query.text.toString())
         }
 
-        val toggle = ActionBarDrawerToggle(
-            this, drawer_layout, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close
-        )
+        val toggle: ActionBarDrawerToggle = object :
+            ActionBarDrawerToggle(
+                this,
+                drawer_layout,
+                toolbar,
+                R.string.navigation_drawer_open,
+                R.string.navigation_drawer_close
+            ) {
+            override
+            fun onDrawerOpened(drawerView: View) {
+                super.onDrawerOpened(drawerView)
+                val inputMethodManager: InputMethodManager =
+                    getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                inputMethodManager.hideSoftInputFromWindow(currentFocus.windowToken, 0)
+
+                profile_section.setOnClickListener {
+                    val intent = Intent(applicationContext, UserProfileActivity::class.java)
+                    startActivity(intent)
+                }
+            }
+        }
         drawer_layout.addDrawerListener(toggle)
         toggle.syncState()
 

--- a/visionppi/app/src/main/res/layout/nav_header_main.xml
+++ b/visionppi/app/src/main/res/layout/nav_header_main.xml
@@ -13,6 +13,12 @@
         android:orientation="vertical"
         android:gravity="bottom">
 
+    <LinearLayout
+            android:id="@+id/profile_section"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true">
+
     <ImageView
             android:layout_width="98dp"
             android:layout_height="90dp"
@@ -28,5 +34,5 @@
             android:paddingTop="@dimen/nav_header_vertical_spacing"
             android:text=""
             android:textAppearance="@style/TextAppearance.AppCompat.Body1"/>
-
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Fix #44 

Clicking on the profile icon on the nav drawer header leads to opening the profile page. 