### PR TITLE
Changed responsiveness of Login button based on emptiness of field

### DIFF
--- a/visionppi/app/src/main/java/org/mifos/visionppi/ui/login/LoginActivity.kt
+++ b/visionppi/app/src/main/java/org/mifos/visionppi/ui/login/LoginActivity.kt
@@ -8,6 +8,9 @@ import androidx.databinding.DataBindingUtil
 import org.mifos.visionppi.R
 import org.mifos.visionppi.databinding.ActivityLoginBinding
 import android.os.StrictMode
+import android.text.Editable
+import android.text.TextWatcher
+import kotlinx.android.synthetic.main.activity_login.*
 import org.mifos.visionppi.ui.home.MainActivity
 
 
@@ -31,6 +34,52 @@ class LoginActivity: AppCompatActivity(), LoginMVPView {
         }
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_login)
+
+        binding.etUsername.addTextChangedListener(object : TextWatcher{
+            override fun afterTextChanged(p0: Editable?) {
+
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                if(et_password.text.toString().isNotEmpty() && et_username.text.toString().isNotEmpty()) {
+                    login_btn.alpha = 1.0F
+                    login_btn.isEnabled = true
+                }
+                else{
+                    login_btn.alpha = 0.5F
+                    login_btn.isEnabled = false
+                }
+            }
+
+        })
+
+        binding.etPassword.addTextChangedListener(object : TextWatcher{
+            override fun afterTextChanged(p0: Editable?) {
+
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                if(et_password.text.toString().isNotEmpty() && et_username.text.toString().isNotEmpty()) {
+                    login_btn.alpha = 1.0F
+                    login_btn.isEnabled = true
+                }
+                else{
+                    login_btn.alpha = 0.5F
+                    login_btn.isEnabled = false
+                }
+            }
+
+        })
+        binding.loginBtn.alpha = 0.5F
+        binding.loginBtn.isEnabled = false
+
         binding.loginBtn.setOnClickListener {
             login()
         }

--- a/visionppi/app/src/main/res/layout/activity_login.xml
+++ b/visionppi/app/src/main/res/layout/activity_login.xml
@@ -77,19 +77,22 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
             </com.google.android.material.textfield.TextInputLayout>
+
             <Button
-                    android:text="@string/login_btn_text"
+                    android:id="@+id/login_btn"
+                    style="@style/Button"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:id="@+id/login_btn"
-                    android:layout_marginTop="@dimen/ll_margin"
-                    android:paddingLeft="@dimen/text_input_spacing"
-                    android:paddingRight="@dimen/text_input_spacing"
-                    android:paddingStart="@dimen/text_input_spacing"
-                    android:paddingEnd="@dimen/text_input_spacing"
                     android:layout_marginLeft="@dimen/text_input_spacing"
+                    android:layout_marginTop="@dimen/ll_margin"
                     android:layout_marginRight="@dimen/text_input_spacing"
-                    style="@style/Button"/>
+                    android:alpha="0.5"
+                    android:enabled="false"
+                    android:paddingStart="@dimen/text_input_spacing"
+                    android:paddingLeft="@dimen/text_input_spacing"
+                    android:paddingEnd="@dimen/text_input_spacing"
+                    android:paddingRight="@dimen/text_input_spacing"
+                    android:text="@string/login_btn_text" />
         </LinearLayout>
     </LinearLayout>
 </layout>


### PR DESCRIPTION
Fixes #77 

Login button becomes responsive only when both the username and password fields are not empty, otherwise it remains translucent and disabled