### PR TITLE
Fix #68 Show user a message if analyse images is pressed without any images selected

### DIFF
--- a/visionppi/app/src/main/java/org/mifos/visionppi/ui/computer_vision/ComputerVisionActivity.kt
+++ b/visionppi/app/src/main/java/org/mifos/visionppi/ui/computer_vision/ComputerVisionActivity.kt
@@ -69,7 +69,11 @@ class ComputerVisionActivity : AppCompatActivity(), ComputerVisionMVPView {
         analyse.setOnClickListener {
             counter = 0
             imageNos = images.size
-            analyzeImages()
+            if (images.isNotEmpty()) {
+                analyzeImages()
+            } else {
+                Toast.makeText(this, "Please select at least 1 image", Toast.LENGTH_SHORT).show()
+            }
         }
 
         readLabels()


### PR DESCRIPTION

Fixes #68 

Changes: The user is shown a toast message if a user presses the analyze button without selected any button. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run `./gradlew spotlessCheck` to ensure the code formatting is maintained.

- [X] Run the unit tests with `./gradlew check` to make sure you didn't break anything
